### PR TITLE
Remove langrinder and update Fluent Telegrinder

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,16 +6,7 @@
 
 ## 📦 Libraries
 
-### [Langrinder](https://github.com/ventuero/langrinder)
-
-Flexible internationalization (i18n) engine based on Mako templates
-
-- Based on mako templates. Maximum flexibility and comfort
-- Flexible compilers & parsers (default: JSON compiler)
-- Telegrinder integration
-
-
-### [Fluent Telegrinder](https://github.com/ventuero/fluent-telegrinder)
+### [Fluent Telegrinder](https://github.com/plaicd/fluent-telegrinder)
 
 [Fluent](https://projectfluent.org) i18n implementation for telegrinder
 


### PR DESCRIPTION
Langrinder was removed due to the availability of a more powerful and advanced tool, Fluent Telegrinder. Langrinder, due to its Mako templates, is generally slower than Fluent Telegrinder.
Updated repository URL for Fluent Telegrinder.